### PR TITLE
Remove zip_safe flag to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,4 @@ setup(
     install_requires=['django>=3', 'django-configurations[database,email]'],
     packages=find_packages(),
     include_package_data=True,
-    # Django templates cannot be streamed from a ZIP
-    zip_safe=False,
 )


### PR DESCRIPTION
I looked into this and found this comment:
https://github.com/python/mypy/issues/8802#issuecomment-628249236

Even when using `setup.py install`, setuptools will automatically add the flag if it detects any package data present.

https://setuptools.readthedocs.io/en/latest/userguide/miscellaneous.html#setting-the-zip-safe-flag