### PR TITLE
Enable all django-debug-toolbar panels

### DIFF
--- a/composed_configuration/_debug.py
+++ b/composed_configuration/_debug.py
@@ -27,6 +27,8 @@ class DebugMixin(ConfigMixin):
         # included in a production configuration
         # Only lookup the DEBUG setting once, instead of on every callback
         debug = self.DEBUG
+        # See https://django-debug-toolbar.readthedocs.io/en/latest/configuration.html#toolbar-options
         return {
             'SHOW_TOOLBAR_CALLBACK': lambda request: debug,
+            'DISABLE_PANELS': set(),
         }


### PR DESCRIPTION
All this done for now is enable the 'Intercept redirects' panel, which is useful for debugging/profiling SSR forms.