### PR TITLE
Make the log filters more robust to differently-formatted messages

### DIFF
--- a/composed_configuration/_logging.py
+++ b/composed_configuration/_logging.py
@@ -9,14 +9,22 @@ def _filter_favicon_requests(record):
     ):
         return False
 
-    if record.name == 'django.server' and str(record.args[0]).startswith('GET /favicon.ico '):
+    if (
+        record.name == 'django.server'
+        and len(record.args) >= 1
+        and str(record.args[0]).startswith('GET /favicon.ico ')
+    ):
         return False
 
     return True
 
 
 def _filter_static_requests(record):
-    if record.name == 'django.server' and str(record.args[0]).startswith('GET /static/'):
+    if (
+        record.name == 'django.server'
+        and len(record.args) >= 1
+        and str(record.args[0]).startswith('GET /static/')
+    ):
         return False
 
     return True


### PR DESCRIPTION
It is possible for a rare code path (sending an HTTPS request to a development server) to cause a message with empty `.args` to be sent to the `django.server` logger.

Fixes #121.