### PR TITLE
Add the DEFAULT_AUTO_FIELD setting from Django 3.2

### DIFF
--- a/composed_configuration/_django.py
+++ b/composed_configuration/_django.py
@@ -67,6 +67,8 @@ class DjangoMixin(ConfigMixin):
         },
     ]
 
+    DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
     # Password validation
     # https://docs.djangoproject.com/en/3.0/ref/settings/#auth-password-validators
     AUTH_PASSWORD_VALIDATORS = [


### PR DESCRIPTION
Since the implicit old default was AutoField, this may cause a migration.