### PR TITLE
Set Eastern Time as the default timezone

### DIFF
--- a/composed_configuration/_django.py
+++ b/composed_configuration/_django.py
@@ -85,6 +85,6 @@ class DjangoMixin(ConfigMixin):
     # https://docs.djangoproject.com/en/3.0/topics/i18n/
     LANGUAGE_CODE = 'en-us'
     USE_TZ = True
-    TIME_ZONE = 'UTC'
+    TIME_ZONE = 'America/New_York'
     USE_I18N = True
     USE_L10N = True


### PR DESCRIPTION
This resulted from a [discussion](https://github.com/girder/cookiecutter-girder-4/pull/139#discussion_r593494307) about timezone defaults in [the cookiecutter repo](https://github.com/girder/cookiecutter-girder-4/pull/139).