### PR TITLE
Set an increased `RESULTS_CACHE_SIZE` for django-debug-toolbar

### DIFF
--- a/composed_configuration/_debug.py
+++ b/composed_configuration/_debug.py
@@ -19,4 +19,7 @@ class DebugMixin(ConfigMixin):
         # such as GZipMiddleware.
         configuration.MIDDLEWARE.insert(0, 'debug_toolbar.middleware.DebugToolbarMiddleware')
 
-    RESULTS_CACHE_SIZE = 250
+    DEBUG_TOOLBAR_CONFIG = {
+        # The default size often is too small, causing an inability to view queries
+        'RESULTS_CACHE_SIZE': 250,
+    }

--- a/composed_configuration/_debug.py
+++ b/composed_configuration/_debug.py
@@ -18,3 +18,5 @@ class DebugMixin(ConfigMixin):
         # However, it must come after any other middleware that encodes the response’s content,
         # such as GZipMiddleware.
         configuration.MIDDLEWARE.insert(0, 'debug_toolbar.middleware.DebugToolbarMiddleware')
+
+    RESULTS_CACHE_SIZE = 250


### PR DESCRIPTION
Otherwise when viewing the SQL panel the queries may already be evicted from RAM.