### PR TITLE
Rename ConfigMixin.before_binding to mutate_configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ class _ProjectMixin(ConfigMixin):
     pass
 
     @staticmethod
-    def before_binding(configuration: ComposedConfiguration) -> None:
+    def mutate_configuration(configuration: ComposedConfiguration) -> None:
         # Perform any non-overriding mutation of existing settings here
         # The "configuration" variable contains the flattened settings
         # For example:

--- a/composed_configuration/_allauth.py
+++ b/composed_configuration/_allauth.py
@@ -11,7 +11,7 @@ class AllauthMixin(ConfigMixin):
     """
 
     @staticmethod
-    def before_binding(configuration: Type[ComposedConfiguration]) -> None:
+    def mutate_configuration(configuration: Type[ComposedConfiguration]) -> None:
         configuration.INSTALLED_APPS += [
             'django.contrib.sites',
             'allauth',

--- a/composed_configuration/_base.py
+++ b/composed_configuration/_base.py
@@ -1,4 +1,5 @@
 from typing import Type
+import warnings
 
 from configurations import Configuration, values
 from configurations.base import ConfigurationBase
@@ -6,7 +7,7 @@ from configurations.base import ConfigurationBase
 # With the default "late_binding=False", and "environ_name" is specified or "environ=False",
 # even Values from non-included classes (e.g. `AWS_DEFAULT_REGION) get immediately evaluated and
 # expect env vars to be set. Also, immediately evaluated Values cannot be tweaked effectively
-# in "before_binding").
+# in "mutate_configuration").
 values.Value.late_binding = True
 
 
@@ -44,8 +45,15 @@ class ComposedConfiguration(Configuration, metaclass=FixedConfigurationBase):
         # For every class in the inheritance hierarchy
         # Reverse order allows more base classes to run first
         for base_cls in reversed(cls.__mro__):
-            # If the class has "before_binding" as its own (non-inherited) method
-            if 'before_binding' in base_cls.__dict__:
+            # If the class has "mutate_configuration" as its own (non-inherited) method
+            if 'mutate_configuration' in base_cls.__dict__:
+                base_cls.mutate_configuration(cls)
+            elif 'before_binding' in base_cls.__dict__:
+                warnings.warn(
+                    'In "ConfigMixin" subclasses, '
+                    '"before_binding" should be renamed to "mutate_configuration"',
+                    DeprecationWarning,
+                )
                 base_cls.before_binding(cls)
 
 
@@ -53,9 +61,9 @@ class ConfigMixin:
     """Abstract mixin for composable Config sections."""
 
     @staticmethod
-    def before_binding(configuration: Type[ComposedConfiguration]) -> None:
+    def mutate_configuration(configuration: Type[ComposedConfiguration]) -> None:
         """
-        Run before values are fully bound with environment variables.
+        Mutate the configuration before values are fully bound with environment variables.
 
         `configuration` refers to the final Configuration class, so settings from
         other Configs in the final hierarchy may be referenced.

--- a/composed_configuration/_cors.py
+++ b/composed_configuration/_cors.py
@@ -18,7 +18,7 @@ class CorsMixin(ConfigMixin):
     """
 
     @staticmethod
-    def before_binding(configuration: Type[ComposedConfiguration]) -> None:
+    def mutate_configuration(configuration: Type[ComposedConfiguration]) -> None:
         configuration.INSTALLED_APPS += ['corsheaders']
 
         # CorsMiddleware must be added immediately before WhiteNoiseMiddleware, so this can

--- a/composed_configuration/_database.py
+++ b/composed_configuration/_database.py
@@ -16,7 +16,7 @@ class DatabaseMixin(ConfigMixin):
     """
 
     @staticmethod
-    def before_binding(configuration: Type[ComposedConfiguration]) -> None:
+    def mutate_configuration(configuration: Type[ComposedConfiguration]) -> None:
         configuration.INSTALLED_APPS += ['django.contrib.postgres']
 
     # This cannot have a default value, since the password and database

--- a/composed_configuration/_debug.py
+++ b/composed_configuration/_debug.py
@@ -11,7 +11,7 @@ class DebugMixin(ConfigMixin):
     """
 
     @staticmethod
-    def before_binding(configuration: Type[ComposedConfiguration]) -> None:
+    def mutate_configuration(configuration: Type[ComposedConfiguration]) -> None:
         configuration.INSTALLED_APPS += ['debug_toolbar']
 
         # Include Debug Toolbar middleware as early as possible in the list.

--- a/composed_configuration/_django.py
+++ b/composed_configuration/_django.py
@@ -21,7 +21,7 @@ class DjangoMixin(ConfigMixin):
     """
 
     @staticmethod
-    def before_binding(configuration: Type[ComposedConfiguration]) -> None:
+    def mutate_configuration(configuration: Type[ComposedConfiguration]) -> None:
         # These are often extended, so update their values to avoid fragility due to mixin ordering
         configuration.INSTALLED_APPS += [
             'django.contrib.admin',

--- a/composed_configuration/_email.py
+++ b/composed_configuration/_email.py
@@ -23,7 +23,7 @@ class SmtpEmailMixin(_EmailMixin):
     """
 
     @staticmethod
-    def before_binding(configuration: Type[ComposedConfiguration]) -> None:
+    def mutate_configuration(configuration: Type[ComposedConfiguration]) -> None:
         email = cast(
             Dict[str, str],
             values.EmailURLValue(

--- a/composed_configuration/_extensions.py
+++ b/composed_configuration/_extensions.py
@@ -11,7 +11,7 @@ class ExtensionsMixin(ConfigMixin):
     """
 
     @staticmethod
-    def before_binding(configuration: Type[ComposedConfiguration]) -> None:
+    def mutate_configuration(configuration: Type[ComposedConfiguration]) -> None:
         configuration.INSTALLED_APPS += ['django_extensions']
 
     SHELL_PLUS_PRINT_SQL = True

--- a/composed_configuration/_filter.py
+++ b/composed_configuration/_filter.py
@@ -11,5 +11,5 @@ class FilterMixin(ConfigMixin):
     """
 
     @staticmethod
-    def before_binding(configuration: Type[ComposedConfiguration]) -> None:
+    def mutate_configuration(configuration: Type[ComposedConfiguration]) -> None:
         configuration.INSTALLED_APPS += ['django_filters']

--- a/composed_configuration/_rest_framework.py
+++ b/composed_configuration/_rest_framework.py
@@ -12,7 +12,7 @@ class RestFrameworkMixin(ConfigMixin):
     """
 
     @staticmethod
-    def before_binding(configuration: Type[ComposedConfiguration]) -> None:
+    def mutate_configuration(configuration: Type[ComposedConfiguration]) -> None:
         configuration.INSTALLED_APPS += [
             'rest_framework',
             'rest_framework.authtoken',

--- a/composed_configuration/_sentry.py
+++ b/composed_configuration/_sentry.py
@@ -18,7 +18,7 @@ class SentryMixin(ConfigMixin):
     """
 
     @staticmethod
-    def before_binding(configuration: Type[ComposedConfiguration]) -> None:
+    def mutate_configuration(configuration: Type[ComposedConfiguration]) -> None:
         configuration.INSTALLED_APPS += [
             'composed_configuration.sentry.apps.SentryConfig',
         ]

--- a/composed_configuration/_static.py
+++ b/composed_configuration/_static.py
@@ -38,7 +38,7 @@ class StaticFileMixin(ConfigMixin):
         )
 
     @staticmethod
-    def before_binding(configuration: Type[ComposedConfiguration]) -> None:
+    def mutate_configuration(configuration: Type[ComposedConfiguration]) -> None:
         configuration.INSTALLED_APPS += ['django.contrib.staticfiles']
 
 
@@ -50,7 +50,7 @@ class WhitenoiseStaticFileMixin(StaticFileMixin):
     """
 
     @staticmethod
-    def before_binding(configuration: Type[ComposedConfiguration]) -> None:
+    def mutate_configuration(configuration: Type[ComposedConfiguration]) -> None:
         # Insert immediately before staticfiles app
         staticfiles_index = configuration.INSTALLED_APPS.index('django.contrib.staticfiles')
         configuration.INSTALLED_APPS.insert(staticfiles_index, 'whitenoise.runserver_nostatic')


### PR DESCRIPTION
The old name is deprecated, but will continue to work.