### PR TITLE
Set CELERY_TASK_REJECT_ON_WORKER_LOST and CELERY_TASK_ACKS_ON_FAILURE_OR_TIMEOUT

### DIFF
--- a/composed_configuration/_celery.py
+++ b/composed_configuration/_celery.py
@@ -35,6 +35,20 @@ class CeleryMixin(ConfigMixin):
     def CELERY_TASK_ACKS_LATE(self):  # noqa: N802
         return False if self.DEBUG else True
 
+    # Ensure that unexpectedly killed tasks (e.g. due a cold shutdown from a SIGQUIT) will be
+    # requeued. However, this also causes tasks which are killed due to intrinsic causes (e.g. a
+    # segfault or OOM) to be requeued, whereby they are likely crash again.
+    # See: https://docs.celeryproject.org/en/stable/userguide/tasks.html#tasks for more explanation
+    # of these tradeoffs.
+    # This does not affect warm shutdowns from a SIGTERM (which the process supervisor ought to
+    # send), which allows Celery to complete running tasks; see:
+    # https://docs.celeryproject.org/en/stable/userguide/workers.html#process-signals for reference.
+    CELERY_TASK_REJECT_ON_WORKER_LOST = True
+
+    # When tasks fail due to their own internally-raised exception or due to timeout, do not
+    # requeue. It's expected that they wouldn't succeed if run again. This is Celery's default.
+    CELERY_TASK_ACKS_ON_FAILURE_OR_TIMEOUT = True
+
     # This is sensible behavior with TASKS_ACKS_LATE, this must be enabled to prevent warnings,
     # and this will be Celery's default in 6.0.
     CELERY_WORKER_CANCEL_LONG_RUNNING_TASKS_ON_CONNECTION_LOSS = True


### PR DESCRIPTION
These do not change the defaults, but are important for task reliability. See inline comments for a full rationale.