### PR TITLE
Add 'django' to ALLOWED_HOSTS in dev config

### DIFF
--- a/composed_configuration/_configuration.py
+++ b/composed_configuration/_configuration.py
@@ -48,7 +48,7 @@ class DevelopmentBaseConfiguration(
     DEBUG = True
     SECRET_KEY = 'insecuresecret'
 
-    ALLOWED_HOSTS = values.ListValue(['localhost', '127.0.0.1'])
+    ALLOWED_HOSTS = values.ListValue(['localhost', '127.0.0.1', 'django'])
     CORS_ORIGIN_REGEX_WHITELIST = values.ListValue(
         [r'^https?://localhost:\d+$', r'^https?://127\.0\.0\.1:\d+$']
     )


### PR DESCRIPTION
This is to support other services communicating with django over HTTP in a docker-compose development environment.

I realize this might not be in scope here. Hopefully the maintainers can recommend a better alternative to achieve this if this isn't the right place.