### PR TITLE
Disable PRETTIFY_SQL in Django debug toolbar

### DIFF
--- a/composed_configuration/_debug.py
+++ b/composed_configuration/_debug.py
@@ -22,4 +22,6 @@ class DebugMixin(ConfigMixin):
     DEBUG_TOOLBAR_CONFIG = {
         # The default size often is too small, causing an inability to view queries
         'RESULTS_CACHE_SIZE': 250,
+        # If this setting is True, large sql queries can cause the page to render slowly
+        'PRETTIFY_SQL': False,
     }


### PR DESCRIPTION
Related - https://github.com/jazzband/django-debug-toolbar/issues/1402

This has bitten me a few times now, the rendering is so slow in some cases the page doesn't even render.