### PR TITLE
Add '0.0.0.0' to ALLOWED_HOSTS in DevelopmentBaseConfiguration

### DIFF
--- a/composed_configuration/_configuration.py
+++ b/composed_configuration/_configuration.py
@@ -48,9 +48,9 @@ class DevelopmentBaseConfiguration(
     DEBUG = True
     SECRET_KEY = 'insecuresecret'
 
-    ALLOWED_HOSTS = values.ListValue(['localhost', '127.0.0.1'])
+    ALLOWED_HOSTS = values.ListValue(['localhost', '127.0.0.1', '0.0.0.0'])
     CORS_ORIGIN_REGEX_WHITELIST = values.ListValue(
-        [r'^https?://localhost:\d+$', r'^https?://127\.0\.0\.1:\d+$']
+        [r'^https?://localhost:\d+$', r'^https?://127\.0\.0\.1:\d+$', r'^https?://0\.0\.0\.0:\d+$']
     )
 
     # When in Docker, the bridge network sends requests from the host machine exclusively via a


### PR DESCRIPTION
Upon spinning up a new Django Project from the cookie-cutter, you get the following prompt:

```bash
(django) ➜  my-new-project docker compose up django
[+] Running 4/0
 ⠿ Container my-new-project-postgres-1  Running                                                                    0.0s
 ⠿ Container my-new-project-minio-1     Running                                                                    0.0s
 ⠿ Container my-new-project-rabbitmq-1  Running                                                                    0.0s
 ⠿ Container my-new-project-django-1    Created                                                                    0.1s
Attaching to my-new-project-django-1
my-new-project-django-1  | django-configurations version 2.3.2, using configuration DevelopmentConfiguration
my-new-project-django-1  | [02:49:48] INFO     Watching for file changes with             autoreload.py:643
my-new-project-django-1  |                     StatReloader
my-new-project-django-1  | Performing system checks...
my-new-project-django-1  |
my-new-project-django-1  | System check identified no issues (0 silenced).
my-new-project-django-1  | February 08, 2022 - 02:49:48
my-new-project-django-1  | Django version 4.0.2, using settings 'my_new_project.settings'
my-new-project-django-1  | Starting development server at http://0.0.0.0:8000/
my-new-project-django-1  | Quit the server with CONTROL-C.
```

Clicking on the output link `http://0.0.0.0:8000/` or going to `http://0.0.0.0:8000/admin` (because there aren't any pages in the empty project) then yields a 400 error:

```
my-new-project-django-1  | [02:53:35] ERROR    Invalid HTTP_HOST header: '0.0.0.0:8000'.    exception.py:99
my-new-project-django-1  |                     You may need to add '0.0.0.0' to
my-new-project-django-1  |                     ALLOWED_HOSTS.
my-new-project-django-1  |            WARNING  Bad Request: /admin                               log.py:225
my-new-project-django-1  |            WARNING  "GET /admin HTTP/1.1" 400 81069              basehttp.py:179
my-new-project-django-1  |            ERROR    Invalid HTTP_HOST header: '0.0.0.0:8000'.    exception.py:99
my-new-project-django-1  |                     You may need to add '0.0.0.0' to
my-new-project-django-1  |                     ALLOWED_HOSTS.
```

In order to view the app with default configuration, you must use `http://localhost:8000/admin`

The default values for `ALLOWED_HOSTS` are set in `DevelopmentBaseConfiguration` and disallow `0.0.0.0`.

This PRs adds `0.0.0.0` as an allowed host in `DevelopmentBaseConfiguration` as the cookie-cutter specifically launches the development server to listen on `0.0.0.0` in:

https://github.com/girder/cookiecutter-girder-4/blob/8974eb64a7ff4742d23b2d5eacbc4deebc90ab91/%7B%7B%20cookiecutter.project_slug%20%7D%7D/docker-compose.override.yml#L7

I believe we have to bind the server to `0.0.0.0` so that it can receive any traffic coming in through the docker network and so we should make sure the default "development" configuration supports this