### PR TITLE
Remove `USE_L10N` setting

### DIFF
--- a/composed_configuration/_django.py
+++ b/composed_configuration/_django.py
@@ -87,4 +87,3 @@ class DjangoMixin(ConfigMixin):
     USE_TZ = True
     TIME_ZONE = 'UTC'
     USE_I18N = True
-    USE_L10N = True


### PR DESCRIPTION
This setting is deprecated, and in Django 4 is True by default.

```
RemovedInDjango50Warning: The USE_L10N setting is deprecated. Starting with Django 5.0, localized formatting of data will always be enabled. For example Django will display numbers and dates using the format of the current locale.
    warnings.warn(USE_L10N_DEPRECATED_MSG, RemovedInDjango50Warning)
```

We don't currently require Django 4+, but I think we should consider doing so.