### PR TITLE
Update for breaking change in `django-allauth`

### DIFF
--- a/composed_configuration/_allauth.py
+++ b/composed_configuration/_allauth.py
@@ -28,6 +28,10 @@ class AllauthMixin(ConfigMixin):
         # auth_style should come before others, to ensure its template overrides are found
         configuration.INSTALLED_APPS.insert(0, 'auth_style')
 
+        configuration.MIDDLEWARE += [
+            'allauth.account.middleware.AccountMiddleware',
+        ]
+
     # The sites framework requires this to be set.
     # In the unlikely case where a database's pk sequence for the django_site table is not reset,
     # the default site object could have a different pk. Then this will need to be overridden

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ with readme_file.open() as f:
 
 _base_extras = [
     'django>=4',
-    'django-allauth',
+    # Required for "allauth.account.middleware.AccountMiddleware"
+    'django-allauth>=0.56.0',
     'django-auth-style',
     'django-cors-headers',
     'django-extensions',


### PR DESCRIPTION
As of `django-allauth` 0.56.0, downstream users are required to specify this in their Django `MIDDLEWARE`.
See https://github.com/pennersr/django-allauth/blob/main/ChangeLog.rst#0560-2023-09-07.

Not specifying this middleware results in this error - https://stackoverflow.com/questions/77012106/django-allauth-modulenotfounderror-no-module-named-allauth-account-middlewar

Example of this error occuring in CI on DANDI - https://github.com/dandi/dandi-archive/actions/runs/6114588402/job/16596456625?pr=1674

Fixes #188